### PR TITLE
Field Types refactored

### DIFF
--- a/fields/civicrm_country/class-civicrm-country.php
+++ b/fields/civicrm_country/class-civicrm-country.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * CiviCRM Caldera Forms Country Field Class.
+ *
+ * @since 0.2
+ */
+class CiviCRM_Caldera_Forms_Field_Country {
+
+	/**
+	 * Initialises this object.
+	 *
+	 * @since 0.2
+	 */
+	public function __construct() {
+
+		// register Caldera Forms callbacks
+		$this->register_hooks();
+
+	}
+
+	/**
+	 * Register hooks.
+	 *
+	 * @since 0.2
+	 */
+	public function register_hooks() {
+
+		// add custom fields to Caldera UI
+		add_filter( 'caldera_forms_get_field_types', array( $this, 'register_field_type' ) );
+
+		// render country name
+		add_filter( 'caldera_forms_view_field_civicrm_country', array( $this, 'field_render_view' ), 10, 3 );
+
+	}
+
+	/**
+	 * Adds the field definition for this field type to Caldera UI.
+	 *
+	 * @uses 'caldera_forms_get_field_types' filter
+	 *
+	 * @since 0.2
+	 *
+	 * @param array $field_types The existing fields configuration
+	 * @return array $field_types The modified fields configuration
+	 */
+	public function register_field_type( $field_types ) {
+
+		$field_types['civicrm_country'] = array(
+			'field' => __( 'CiviCRM Country', 'caldera-forms-civicrm' ),
+			'file' => CF_CIVICRM_INTEGRATION_PATH . 'fields/civicrm_country/field.php',
+			'category' => __( 'CiviCRM', 'caldera-forms-civicrm' ),
+			'description' => __( 'CiviCRM Country dropdown', 'caldera-forms-civicrm' ),
+			'setup' => array(
+				'template' => CF_CIVICRM_INTEGRATION_PATH . 'fields/civicrm_country/config.php',
+				'preview' => CF_CIVICRM_INTEGRATION_PATH . 'fields/civicrm_country/preview.php',
+				'default' => array(
+					'placeholder' => __( 'Select a Country', 'caldera-forms-civicrm' ),
+					'default' => CiviCRM_Caldera_Forms_Helper::get_civicrm_settings( 'defaultContactCountry' )
+				),
+			),
+		);
+
+		return $field_types;
+
+	}
+
+	/**
+	 * Renders the view for this field type in the Caldera UI.
+	 *
+	 * @since 0.2
+	 *
+	 * @param array $field_value The field value to populate
+	 * @param array $form The containing form
+	 * @return array $field_value The modified field value
+	 */
+	public function field_render_view( $field_value, $field, $form ) {
+
+		// use API to retrieve Country name
+		$country_data = civicrm_api3( 'Country', 'get', array(
+			'id' => $field_value,
+		));
+
+		// set as view if we get one
+		if ( $country_data['is_error'] == '0' ) {
+			$item = array_pop( $country_data['values'] );
+			$field_value = esc_html( $item['name'] );
+		}
+
+		return $field_value;
+
+	}
+
+}

--- a/fields/civicrm_country/config.php
+++ b/fields/civicrm_country/config.php
@@ -1,3 +1,4 @@
+<?php $countries = CiviCRM_Caldera_Forms_Helper::get_countries(); ?>
 <div class="caldera-config-group">
 	<label><?php _e( 'Placeholder', 'caldera-forms-civicrm' ); ?></label>
 	<div class="caldera-config-field">
@@ -9,28 +10,7 @@
 	<div class="caldera-config-field">
 		<select id="{{_id}}_default" class="block-input field-config" name="{{_name}}[default]" value="{{default}}">
         <option value="" {{#is default value=""}}selected="selected"{{/is}}></option>
-        <?php
-
-		try {
-
-			$country = civicrm_api3( 'Country', 'get', array(
-				'sequential' => 1,
-				'return' => array( 'id', 'name' ),
-				'options' => array( 'limit' => 0 ),
-				'id' => array( 'IN' => CiviCRM_Caldera_Forms_Helper::get_civicrm_settings( 'countryLimit' ) ),
-			));
-
-		} catch ( Exception $e ) {
-			// If no countries enabled in CiviCRM localization settings (CiviCRM_Caldera_Forms::get_civicrm_settings('countryLimit')) get all countries instead
-			$country = civicrm_api3( 'Country', 'get', array(
-				'sequential' => 1,
-				'return' => array( 'id', 'name' ),
-				'options' => array( 'limit' => 0 ),
-			));
-
-		}
-
-        foreach( $country['values'] as $key => $value ) { ?>
+        <?php foreach( $countries['values'] as $key => $value ) { ?>
             <option value="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['name'] ); ?></option>
         <?php } ?>
         </select>

--- a/fields/civicrm_country/field.php
+++ b/fields/civicrm_country/field.php
@@ -1,26 +1,7 @@
-<?php
-
-try {
-
-    $country = civicrm_api3( 'Country', 'get', array(
-        'sequential' => 1,
-        'options' => array( 'limit' => 0 ),
-        'id' => array( 'IN' => CiviCRM_Caldera_Forms_Helper::get_civicrm_settings( 'countryLimit' ) ),
-    ));
-
-} catch ( Exception $e ) {
-    // If no countries enabled in CiviCRM localization settings (CiviCRM_Caldera_Forms::get_civicrm_settings('countryLimit')) get all countries instead
-    $country = civicrm_api3( 'Country', 'get', array(
-        'sequential' => 1,
-        'options' => array( 'limit' => 0 ),
-    ));
-
-}
-
-echo $wrapper_before; ?>
+<?php $countries = CiviCRM_Caldera_Forms_Helper::get_countries(); ?>
+<?php echo $wrapper_before; ?>
 	<?php echo $field_label; ?>
 	<?php echo $field_before; ?>
-		<?php ob_start(); ?>
 		<select <?php echo $field_placeholder; ?> id="<?php echo esc_attr( $field_id . '_cf_civicrm_country' ); ?>" data-field="<?php echo esc_attr( $field_base_id ); ?>" class="<?php echo esc_attr( $field_class ); ?>" name="<?php echo esc_attr( $field_name ); ?>" <?php echo $field_required; ?>>
 			<?php
 
@@ -28,27 +9,18 @@ echo $wrapper_before; ?>
 				echo '<option value="">' . ( ! empty( $field['hide_label'] ) ? esc_html( $field['label'] ) : null ) . '</option>';
 			} else {
 				$sel = '';
-				if ( empty( $field_value ) ) {
-					$sel = 'selected';
-				}
-				echo '<option value="" disabled ' . $sel . '>' . esc_html( $field['config']['placeholder'] ) . '</option>';
+				if ( empty( $field_value ) ) $sel = ' selected="selected"';
+				echo '<option value="" disabled="disabled"' . $sel . '>' . esc_html( $field['config']['placeholder'] ) . '</option>';
 			}
 
-			foreach( $country['values'] as $key => $value ) {
-				echo '<option value="' . esc_attr( $value['id'] ) . '">' . esc_html( $value['name'] ) . '</option>';
+			foreach( $countries['values'] as $key => $value ) {
+				$selected = '';
+				if ( ! empty( $field_value ) && $field_value == $value['id'] ) $selected = ' selected="selected"';
+				echo '<option value="' . esc_attr( $value['id'] ) . '"' . $selected . '>' . esc_html( $value['name'] ) . '</option>';
+			 }
 
-			 } ?>
+			 ?>
 		</select>
-		<?php
-
-		$countries = ob_get_clean();
-		if ( ! empty( $field_value ) ) {
-			$countries = str_replace( 'value="' . $field_value . '"', 'value="' . $field_value . '" selected="selected"', $countries );
-		}
-		echo $countries;
-
-		?>
-
 		<?php echo $field_caption; ?>
 	<?php echo $field_after; ?>
 <?php echo $wrapper_after; ?>

--- a/fields/civicrm_country/preview.php
+++ b/fields/civicrm_country/preview.php
@@ -1,6 +1,6 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
-	<div class="preview-caldera-config-field">		
+	{{#unless hide_label}}<label class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
+	<div class="preview-caldera-config-field">
 		<select class="preview-field-config" {{#if hide_label}}placeholder="{{label}}"{{/if}}>
 		<option value=""></option>
 		{{#each config/option}}

--- a/fields/civicrm_state/class-civicrm-state.php
+++ b/fields/civicrm_state/class-civicrm-state.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * CiviCRM Caldera Forms State Field Class.
+ *
+ * @since 0.2
+ */
+class CiviCRM_Caldera_Forms_Field_State {
+
+	/**
+	 * Initialises this object.
+	 *
+	 * @since 0.2
+	 */
+	public function __construct() {
+
+		// register Caldera Forms callbacks
+		$this->register_hooks();
+
+	}
+
+	/**
+	 * Register hooks.
+	 *
+	 * @since 0.2
+	 */
+	public function register_hooks() {
+
+		// add custom fields to Caldera UI
+		add_filter( 'caldera_forms_get_field_types', array( $this, 'register_field_type' ) );
+
+		// render state name
+		add_filter( 'caldera_forms_view_field_civicrm_state', array( $this, 'field_render_view' ), 10, 3 );
+
+	}
+
+	/**
+	 * Adds the field definition for this field type to Caldera UI.
+	 *
+	 * @uses 'caldera_forms_get_field_types' filter
+	 *
+	 * @since 0.2
+	 *
+	 * @param array $field_types The existing fields configuration
+	 * @return array $field_types The modified fields configuration
+	 */
+	public function register_field_type( $field_types ) {
+
+		$field_types['civicrm_state'] = array(
+			'field' => __( 'CiviCRM State/Province', 'caldera-forms-civicrm' ),
+			'file' => CF_CIVICRM_INTEGRATION_PATH . 'fields/civicrm_state/field.php',
+			'category' => __( 'CiviCRM', 'caldera-forms-civicrm' ),
+			'description' => __( 'CiviCRM State/Province dropdown', 'caldera-forms-civicrm' ),
+			'setup' => array(
+				'template' => CF_CIVICRM_INTEGRATION_PATH . 'fields/civicrm_state/config.php',
+				'preview' => CF_CIVICRM_INTEGRATION_PATH . 'fields/civicrm_state/preview.php',
+				'default' => array(
+					'placeholder' => __( 'Select a State/Province', 'caldera-forms-civicrm' ),
+					'default' => CiviCRM_Caldera_Forms_Helper::get_civicrm_settings( 'defaultContactStateProvince' )
+				),
+			),
+		);
+
+		return $field_types;
+
+	}
+
+	/**
+	 * Renders the view for this field type in the Caldera UI.
+	 *
+	 * @since 0.2
+	 *
+	 * @param array $field_value The field value to populate
+	 * @param array $form The containing form
+	 * @return array $field_value The modified field value
+	 */
+	public function field_render_view( $field_value, $field, $form ) {
+
+		$states = CiviCRM_Caldera_Forms_Helper::get_state_province();
+
+		// set as view if we get a match
+		foreach( $states as $state_id => $state ) {
+			if ( $state_id == $field_value ) {
+				$field_value = esc_html( $state['name'] );
+				break;
+			}
+		}
+
+		return $field_value;
+
+	}
+
+}

--- a/fields/civicrm_state/config.php
+++ b/fields/civicrm_state/config.php
@@ -1,3 +1,4 @@
+<?php $state = CiviCRM_Caldera_Forms_Helper::get_state_province(); ?>
 <div class="caldera-config-group">
 	<label><?php _e( 'Placeholder', 'caldera-forms-civicrm' ); ?></label>
 	<div class="caldera-config-field">
@@ -9,9 +10,7 @@
     <div class="caldera-config-field">
         <select id="{{_id}}_default" class="block-input field-config" name="{{_name}}[default]" value="{{default}}">
         <option value="" {{#is default value=""}}selected="selected"{{/is}}></option>
-        <?php
-        $state = CiviCRM_Caldera_Forms_Helper::get_state_province();
-        foreach( $state as $key => $value ) { ?>
+        <?php foreach( $state as $key => $value ) { ?>
             <option value="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $value['name'] ); ?></option>
         <?php } ?>
         </select>

--- a/fields/civicrm_state/field.php
+++ b/fields/civicrm_state/field.php
@@ -1,11 +1,7 @@
-<?php
-
-$state = CiviCRM_Caldera_Forms_Helper::get_state_province();
-
-echo $wrapper_before; ?>
+<?php $state = CiviCRM_Caldera_Forms_Helper::get_state_province(); ?>
+<?php echo $wrapper_before; ?>
 	<?php echo $field_label; ?>
 	<?php echo $field_before; ?>
-		<?php ob_start(); ?>
 		<select <?php echo $field_placeholder; ?> id="<?php echo esc_attr( $field_id . '_cf_civicrm_state' ); ?>" data-field="<?php echo esc_attr( $field_base_id ); ?>" class="<?php echo esc_attr( $field_class ); ?>" name="<?php echo esc_attr( $field_name ); ?>" <?php echo $field_required; ?>>
 			<?php
 
@@ -13,27 +9,16 @@ echo $wrapper_before; ?>
 				echo '<option value="">' . ( ! empty( $field['hide_label'] ) ? esc_html( $field['label'] ) : null ) . '</option>';
 			} else {
 				$sel = '';
-				if( empty( $field_value ) ) {
-					$sel = 'selected';
-				}
-				echo '<option value="" disabled ' . $sel . '>' . esc_html( $field['config']['placeholder'] ) . '</option>';
+				if ( empty( $field_value ) ) $sel = ' selected="selected"';
+				echo '<option value="" disabled="disabled" ' . $sel . '>' . esc_html( $field['config']['placeholder'] ) . '</option>';
 			}
 
 			foreach( $state as $key => $value ) {
-				echo '<option value="' . esc_attr( $key ) . '" data-crm-country-id="' . esc_attr( $value['country_id'] ) . '">' . esc_html( $value['name'] ) . '</option>';
-
+				$selected = '';
+				if ( ! empty( $field_value ) && $field_value == $key ) $selected = ' selected="selected"';
+				echo '<option value="' . esc_attr( $key ) . '" data-crm-country-id="' . esc_attr( $value['country_id'] ) . '"' . $selected . '>' . esc_html( $value['name'] ) . '</option>';
 			 } ?>
 		</select>
-		<?php
-
-		$states = ob_get_clean();
-		if( ! empty( $field_value ) ) {
-			$states = str_replace( 'value="' . $field_value . '"', 'value="' . $field_value . '" selected="selected"', $states );
-		}
-		echo $states;
-
-		?>
-
 		<script type="text/javascript">
 			jQuery(document).ready( function() {
 				var cfCountries = jQuery('select[id*="_cf_civicrm_country"]');
@@ -51,7 +36,6 @@ echo $wrapper_before; ?>
 				}
 			});
 		</script>
-
 		<?php echo $field_caption; ?>
 	<?php echo $field_after; ?>
 <?php echo $wrapper_after; ?>

--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -26,6 +26,15 @@ class CiviCRM_Caldera_Forms_Helper {
 	public static $activity_fields = array( 'activity_type_id', 'phone_id', 'phone_number', 'status_id', 'priority_id', 'parent_id', 'is_test', 'medium_id', 'is_auto', 'is_current_revision', 'result', 'is_deleted', 'campaign_id', 'engagement_level', 'weight', 'id', 'original_id', 'relationship_id');
 
 	/**
+	 * Holds CiviCRM state/province data which only needs a single lookup.
+	 *
+	 * @since 0.2
+	 * @access public
+	 * @var array $states The CiviCRM state/province data
+	 */
+	public static $states;
+
+	/**
 	 * Holds contact ids for linking processors.
 	 *
 	 * @since 0.1
@@ -197,6 +206,34 @@ class CiviCRM_Caldera_Forms_Helper {
 	}
 
 	/**
+	 * Get Countries from CiviCRM.
+	 *
+	 * @since 0.2
+	 *
+	 * @return array $states The array of countries
+	 */
+	public static function get_countries() {
+
+		// define basic API vars
+		$api_vars = array(
+			'sequential' => 1,
+			'options' => array( 'limit' => 0 ),
+		);
+
+		// get the countries enabled in CiviCRM localization settings
+		$countries_enabled = CiviCRM_Caldera_Forms_Helper::get_civicrm_settings( 'countryLimit' );
+
+		// limit to these if there are some defined
+		if ( ! empty( $countries_enabled ) ) {
+			$api_vars['id'] = array( 'IN' => $countries_enabled );
+		}
+
+		// okay, let's hit the API
+		return civicrm_api3( 'Country', 'get', $api_vars );
+
+	}
+
+	/**
 	 * Get State/Province from CiviCRM.
 	 *
 	 * @since 0.1
@@ -205,21 +242,24 @@ class CiviCRM_Caldera_Forms_Helper {
 	 */
 	public static function get_state_province() {
 
+		// send data back if already retrieved
+		if ( isset( self::$states ) ) return self::$states;
+
 		$query = 'SELECT name,id,country_id FROM civicrm_state_province';
 		$dao = CRM_Core_DAO::executeQuery( $query );
-		$states = array();
+		self::$states = array();
 
 		while ( $dao->fetch() ) {
-			$states[$dao->id] = array( 'name' => $dao->name, 'country_id' => $dao->country_id );
+			self::$states[$dao->id] = array( 'name' => $dao->name, 'country_id' => $dao->country_id );
 		}
 
-		foreach ( $states as $state_id => $state ) {
+		foreach ( self::$states as $state_id => $state ) {
 			if ( ! in_array( $state['country_id'], self::get_civicrm_settings( 'countryLimit' ) ) ) {
-				unset( $states[$state_id] );
+				unset( self::$states[$state_id] );
 			}
 		}
 
-		return $states;
+		return self::$states;
 
 	}
 


### PR DESCRIPTION
I wish I'd split this into smaller commits, but separating the field types out into their own files had knock-on effects. I've made the structure of the field type classes simpler and more encapsulated, so that creating new ones should be more logical. Both Country and State/Province fields now populate their proper `view` attributes in form submissions.