### PR TITLE
Skip status calculation instead of overriding for pay later memberships.

### DIFF
--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -177,7 +177,8 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 						isset( $line_items[$count]['params']['membership_type_id'] ) && $this->is_pay_later ) {
 							// set membership as pending
 							$line_items[$count]['params']['status_id'] = 'Pending';
-							$line_items[$count]['params']['is_override'] = 1;
+							$line_items[$count]['params']['is_pay_later'] = 1;
+							$line_items[$count]['params']['skipStatusCal'] = 1;
 					}
 				}
 				$count++;


### PR DESCRIPTION
The Order processor alters membership line items to create memberships with is_status_override set, breaking later status calculation even though completing a related contribution changes it from Pending.

This PR changes things so that the line items create Pending memberships with is_pay_later and tell the API to skip status calculation.  Automatic status calculation works from this point.