### PR TITLE
Correct renewal behavior for Expired and Pay Later memberships

### DIFF
--- a/processors/membership/class-membership-processor.php
+++ b/processors/membership/class-membership-processor.php
@@ -135,11 +135,11 @@ class CiviCRM_Caldera_Forms_Membership_Processor {
 
 			// renew/extend necessary params
 			if ( isset( $config['is_renewal'] ) && isset( $is_member['id'] ) ) {
-        $form_values['id'] = $is_member['id'];
+				$form_values['id'] = $is_member['id'];
 
-        // Ask the API to calculate the status for us.
-        $form_values['skipStatusCal'] = 0;
-      }
+				// Ask the API to calculate the status for us.
+				$form_values['skipStatusCal'] = 0;
+			}
 
 			$form_values['source'] = isset( $form_values['source'] ) ? $form_values['source'] : $form['name'];
 

--- a/processors/membership/class-membership-processor.php
+++ b/processors/membership/class-membership-processor.php
@@ -134,8 +134,12 @@ class CiviCRM_Caldera_Forms_Membership_Processor {
 			$form_values['contact_id'] = $transient->contacts->{$this->contact_link};
 
 			// renew/extend necessary params
-			if ( isset( $config['is_renewal'] ) && isset( $is_member['id'] ) )
-				$form_values['id'] = $is_member['id'];
+			if ( isset( $config['is_renewal'] ) && isset( $is_member['id'] ) ) {
+        $form_values['id'] = $is_member['id'];
+
+        // Ask the API to calculate the status for us.
+        $form_values['skipStatusCal'] = 0;
+      }
 
 			$form_values['source'] = isset( $form_values['source'] ) ? $form_values['source'] : $form['name'];
 

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -320,8 +320,13 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 
 			// set membership as pending
 			if ( isset( $line_item['params']['membership_type_id'] ) && $this->is_pay_later ) {
-				$line_item['params']['status_id'] = 'Pending';
-				$line_item['params']['is_override'] = 1;
+        if (!$line_item['params']['id']) {
+          $line_item['params']['status_id'] = 'Pending';
+        } else {
+          $line_item['params']['num_terms'] = 0;
+        }
+        $line_item['params']['is_pay_later'] = 1;
+        $line_item['params']['skipStatusCal'] = 1;
 			}
 
 			// set participant as pending

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -320,13 +320,13 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 
 			// set membership as pending
 			if ( isset( $line_item['params']['membership_type_id'] ) && $this->is_pay_later ) {
-        if (!$line_item['params']['id']) {
-          $line_item['params']['status_id'] = 'Pending';
-        } else {
-          $line_item['params']['num_terms'] = 0;
-        }
-        $line_item['params']['is_pay_later'] = 1;
-        $line_item['params']['skipStatusCal'] = 1;
+				if (!$line_item['params']['id']) {
+					$line_item['params']['status_id'] = 'Pending';
+				} else {
+					$line_item['params']['num_terms'] = 0;
+				}
+				$line_item['params']['is_pay_later'] = 1;
+				$line_item['params']['skipStatusCal'] = 1;
 			}
 
 			// set participant as pending


### PR DESCRIPTION
Before
------

* Expired memberships stay Expired on instant payment
* Terms are extended too early for "Current" memberships with is_pay_later option
* "Current" memberships are set to Pending with is_pay_later option
* Memberships created or renewed with is_pay_later have status override set on

After
-----

* Membership processor asks API to recalculate statuses
* Extending membership terms on renewal is deferred to Contribution completion for is_pay_later option
* "Current" memberships remain at the correct status whenever they're renewed.
* Memberships created or renewed with is_pay_later do not change their status override flag, but instead skip status calculation.

Agileware ref CFC-11, CFC-10