### PR TITLE
Autopopulate via query params and process contact ID

### DIFF
--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -21,7 +21,7 @@ class CiviCRM_Caldera_Forms_Helper {
 	 * @access public
 	 * @var aray $contact_fields The contact fields
 	 */
-	public $contact_fields = [ 'prefix_id', 'first_name', 'last_name', 'middle_name', 'suffix_id', 'is_opt_out', 'nick_name', 'source', 'formal_title', 'job_title', 'gender_id', 'birth_date', 'email', 'current_employer', 'do_not_phone', 'do_not_email', 'do_not_mail', 'do_not_sms', 'do_not_trade', 'legal_identifier', 'legal_name', 'preferred_communication_method', 'preferred_language', 'preferred_mail_format', 'communication_style_id', 'household_name', 'organization_name', 'sic_code', 'image_URL' ];
+	public $contact_fields = [ 'prefix_id', 'first_name', 'last_name', 'middle_name', 'suffix_id', 'is_opt_out', 'nick_name', 'source', 'formal_title', 'job_title', 'gender_id', 'birth_date', 'email', 'current_employer', 'do_not_phone', 'do_not_email', 'do_not_mail', 'do_not_sms', 'do_not_trade', 'legal_identifier', 'legal_name', 'preferred_communication_method', 'preferred_language', 'preferred_mail_format', 'communication_style_id', 'household_name', 'organization_name', 'sic_code', 'image_URL', 'id' ];
 
 	/**
 	 * Activity fields.

--- a/processors/contact/class-contact-processor.php
+++ b/processors/contact/class-contact-processor.php
@@ -673,9 +673,12 @@ class CiviCRM_Caldera_Forms_Contact_Processor {
 
 			if( $pr_id['type'] == $this->key_name && isset( $pr_id['runtimes'] ) ){
 
-				if ( isset( $pr_id['config']['auto_pop'] ) && $pr_id['config']['auto_pop'] == 1 && $civicrm_contact_pr[0]['ID'] == $pr_id['ID'] )
+				if ( isset( $pr_id['config']['auto_pop'] ) && $pr_id['config']['auto_pop'] == 1 && $civicrm_contact_pr[0]['ID'] == $pr_id['ID'] ) {
 					// get contact data
 					$contact = $this->plugin->helper->current_contact_data_get();
+				}elseif ( isset( $pr_id['config']['auto_pop_query'] ) && isset($_GET[$pr_id['config']['auto_pop_query']]) ){
+					$contact = $this->plugin->helper->get_civi_contact( $_GET['pid'] );
+				}
 					
 				// Map CiviCRM contact data to form defaults
 				if ( isset( $contact ) && is_array( $contact ) ) {

--- a/processors/contact/contact_config.php
+++ b/processors/contact/contact_config.php
@@ -1,7 +1,12 @@
 <div class="civicrm-entity-fields">
 	<div class="caldera-config-group caldera-config-group-full">
 		<div class="caldera-config-field">
-			<label><input id="auto_pop" type="checkbox" name="{{_name}}[auto_pop]" value="1" {{#if auto_pop}}checked="checked"{{/if}}><?php _e( 'Auto populate contact data with CiviCRM data if user is logged in. (Only for the first contact processor)', 'caldera-forms-civicrm' ); ?></label>
+			<label><input id="auto_pop" type="checkbox" name="{{_name}}[auto_pop]" value="1" {{#if auto_pop}}checked="checked"{{/if}}><?php _e( 'Auto populate with data from the logged in user (only for the first contact processor).', 'caldera-forms-civicrm' ); ?></label>
+		</div>
+	</div>
+	<div class="caldera-config-group caldera-config-group-full">
+		<div class="caldera-config-field">
+			<label><?php _e( 'Auto populate with data from the contact with id specified by the following query parameter', 'caldera-forms-civicrm' ); ?><input id="auto_pop_query" type="text" name="{{_name}}[auto_pop_query]" value="{{auto_pop_query}}"></label>
 		</div>
 	</div>
 	<div class="caldera-config-group caldera-config-group-full">
@@ -140,9 +145,9 @@ $indStandardFields = [ 'first_name', 'last_name', 'middle_name', 'prefix_id', 's
 		}
 	}
 
-	unset( $contactFields['id'], $contactFields['contact_type'], $contactFields['contact_sub_type'] );
+	unset( $contactFields['contact_type'], $contactFields['contact_sub_type'] );
 	$contactFields = array_diff_key( $contactFields, caldera_forms_civicrm()->helper->get_contact_custom_fields() );
-
+	
 	foreach( $contactFields as $key => $value ) { ?>
 	<div class="caldera-config-group" id="<?php echo esc_attr( $key ); ?>"
 		<?php


### PR DESCRIPTION
Hey there,

Here is a patch that allows you to pre-populate contacts into Caldera forms via query params.

It isn't thoroughly thought through (nice alliteration) but is working for me.

A couple of notes on the implementation:

* It does not yet include any ACL. I *think* the best place to add that would be here: https://github.com/michaelmcandrew/caldera-forms-civicrm/blob/b29105973c856bea311570d0dd5053f6a11d4260/processors/contact/class-contact-processor.php#L680

* I realised that allowing the contact id to be processed would be a nice way to carry the state through the form. If you add a hidden contact field for the contact id, it will appears in the form values and the contact will update. The downside is that people have to remember to add a hidden contact id to the 
form. 

There may be other downsides that I am not aware of, but in my preliminary testing, it is working for me. Otherwise, I am presuming that there are other ways to pass the contact ID along (we can't retreive it from _GET as we did when we created the form since that is a separate request).

Anyway, I know that you said that you were thinking about a refactor and potentially a different approach but I thought I would put this out there anyway as food for thought.