### PR TITLE
Price Field has insufficient decimal precision

### DIFF
--- a/fields/presets/class-civicrm-price-sets-presets.php
+++ b/fields/presets/class-civicrm-price-sets-presets.php
@@ -110,6 +110,7 @@ class CiviCRM_Caldera_Forms_Price_Sets_Presets {
 	 * @param  array $field The field config
 	 * @param  array $form The Form config
 	 * @return array The filtered field config
+     * Do not show the price next to the label fields
 	 */
 	public function autopopulate_price_field_values( $field, $form ) {
 
@@ -121,7 +122,7 @@ class CiviCRM_Caldera_Forms_Price_Sets_Presets {
 							foreach ( $price_field['price_field_values'] as $value_id => $price_field_value) {
 								$field['config']['option'][$value_id] = [
 									'value' => $value_id,
-									'label' => $price_field_value['label'] . ' - ' . $field['config']['price_field_currency'] . ' ' . $price_field_value['amount'],
+                                    'label' => $price_field_value['label'] . ' - ' . $field['config']['price_field_currency'] . ' ' . number_format($price_field_value['amount'], 2,  '.', '' ),
 									'calc_value' => $price_field_value['amount']
 								];
 							}

--- a/fields/presets/class-civicrm-price-sets-presets.php
+++ b/fields/presets/class-civicrm-price-sets-presets.php
@@ -122,7 +122,7 @@ class CiviCRM_Caldera_Forms_Price_Sets_Presets {
 							foreach ( $price_field['price_field_values'] as $value_id => $price_field_value) {
 								$field['config']['option'][$value_id] = [
 									'value' => $value_id,
-                                    'label' => $price_field_value['label'] . ' - ' . $field['config']['price_field_currency'] . ' ' . number_format($price_field_value['amount'], 2,  '.', '' ),
+									'label' => $price_field_value['label'] . ' - ' . $field['config']['price_field_currency'] . ' ' . number_format($price_field_value['amount'], 2,  '.', '' ),
 									'calc_value' => $price_field_value['amount']
 								];
 							}

--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -606,7 +606,7 @@ class CiviCRM_Caldera_Forms_Helper {
 
 		$price_field_values = [];
 		foreach ( $all_price_field_values['values'] as $id => $price_field_value ) {
-			$price_field_value['amount'] = number_format( $price_field_value['amount'], 2, '.', '' );
+			$price_field_value['amount'] = number_format( $price_field_value['amount'], 3, '.', '' );
 			$price_field_values[$id] = $price_field_value;
 		}
 
@@ -674,7 +674,7 @@ class CiviCRM_Caldera_Forms_Helper {
 		}
 
 		if ( ! $price_field_value['is_error'] ) {
-			$price_field_value['amount'] = number_format( $price_field_value['amount'], 2, '.', '' );
+			$price_field_value['amount'] = number_format( $price_field_value['amount'], 3, '.', '' );
 			return $price_field_value;
 		}
 

--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -606,7 +606,7 @@ class CiviCRM_Caldera_Forms_Helper {
 
 		$price_field_values = [];
 		foreach ( $all_price_field_values['values'] as $id => $price_field_value ) {
-			$price_field_value['amount'] = number_format( $price_field_value['amount'], 3, '.', '' );
+			$price_field_value['amount'] = number_format( $price_field_value['amount'], 4, '.', '' );
 			$price_field_values[$id] = $price_field_value;
 		}
 
@@ -674,7 +674,7 @@ class CiviCRM_Caldera_Forms_Helper {
 		}
 
 		if ( ! $price_field_value['is_error'] ) {
-			$price_field_value['amount'] = number_format( $price_field_value['amount'], 3, '.', '' );
+			$price_field_value['amount'] = number_format( $price_field_value['amount'], 4, '.', '' );
 			return $price_field_value;
 		}
 


### PR DESCRIPTION
When using the "Price Field" options to auto populate e.g. a Radio field with price options, they are automatically rounded to two decimal places.

This creates problems with tax inclusive price values (eg. GST 10%) due to rounding.

For example, it is impossible to have an option with a price of $60 because $54.54 + 5.454 = 59.994 ≈ $59.99 and $54.55 + 5.455 = 60.005 ≈ $60.01
Therefore, higher precision is required, e.g.: 54.545 + 5.4545 = 59.9995 ≈ $60.00

We have also seen this problem before in Core CiviCRM, which was eventually solved by introducing higher precision price field values.

This PR adds higher precision decimal places.

Agileware Ref: CFC-12