### PR TITLE
When auto-populating a date picker, use the date picker's format

### DIFF
--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -470,7 +470,7 @@ class CiviCRM_Caldera_Forms_Helper {
 
 				// If the CF field is a date picker, convert the date value to the date picker's format.
 				if ( $field['type'] == 'date_picker' && ! empty( $value ) ) {
-					$format = self::translate_date_picker_format( $field['config']['format'] );
+					$format = $this->translate_date_picker_format( $field['config']['format'] );
 					$value = date_create( $value )->format( $format );
 				}
 

--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -468,6 +468,12 @@ class CiviCRM_Caldera_Forms_Helper {
 
 				$value = ! empty( $entity[$civi_field] ) ? $entity[$civi_field] : '';
 
+				// If the CF field is a date picker, convert the date value to the date picker's format.
+				if ( $field['type'] == 'date_picker' && ! empty( $value ) ) {
+					$format = self::translate_date_picker_format( $field['config']['format'] );
+					$value = date_create( $value )->format( $format );
+				}
+
 				/**
 				 * Filter prerenderd value (default value), fires for every processor field.
 				 *
@@ -484,13 +490,6 @@ class CiviCRM_Caldera_Forms_Helper {
 				if ( $field['type'] == 'radio' ) {
 					$options = Caldera_Forms_Field_Util::find_option_values( $field );
 					$form['fields'][$field['ID']]['config']['default'] = array_search( $value, $options );
-				} elseif ( $field['type'] == 'date_picker' ) {
-					// If the date is still in the format returned by the CiviCRM API, convert it to the date picker's format.
-					$filtered_value = &$form['fields'][$field['ID']]['config']['default'];
-					if ( preg_match('/^\d{4}-\d{2}-\d{2}(?: \d{2}:\d{2}:\d{2})?$/', $filtered_value ) ) {
-						$format = self::translate_date_picker_format( $field['config']['format'] );
-						$filtered_value = date_create( $filtered_value )->format( $format );
-					}
 				}
 			}
 		}
@@ -514,6 +513,8 @@ class CiviCRM_Caldera_Forms_Helper {
 			'M'    => 'M',
 			'mm'   => 'm',
 			'm'    => 'n',
+			'DD'   => 'l',
+			'D'    => 'D',
 			'dd'   => 'd',
 			'd'    => 'j',
 		];

--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -484,11 +484,41 @@ class CiviCRM_Caldera_Forms_Helper {
 				if ( $field['type'] == 'radio' ) {
 					$options = Caldera_Forms_Field_Util::find_option_values( $field );
 					$form['fields'][$field['ID']]['config']['default'] = array_search( $value, $options );
+				} elseif ( $field['type'] == 'date_picker' ) {
+					// If the date is still in the format returned by the CiviCRM API, convert it to the date picker's format.
+					$filtered_value = &$form['fields'][$field['ID']]['config']['default'];
+					if ( preg_match('/^\d{4}-\d{2}-\d{2}(?: \d{2}:\d{2}:\d{2})?$/', $filtered_value ) ) {
+						$format = self::translate_date_picker_format( $field['config']['format'] );
+						$filtered_value = date_create( $filtered_value )->format( $format );
+					}
 				}
 			}
 		}
 
 		return $form;
+	}
+
+	/**
+	 * Translate Caldera Forms date picker formats to PHP date formats.
+	 *
+	 * @since 1.0.2
+	 *
+	 * @param string $date_picker_format The Caldera Forms date picker format
+	 */
+	public static function translate_date_picker_format( $date_picker_format ){
+		// Translate each token used in the CF date picker format to the corresponding PHP format character.
+		static $token_map = [
+			'yyyy' => 'Y',
+			'yy'   => 'y',
+			'MM'   => 'F',
+			'M'    => 'M',
+			'mm'   => 'm',
+			'm'    => 'n',
+			'dd'   => 'd',
+			'd'    => 'j',
+		];
+
+		return strtr( $date_picker_format, $token_map );
 	}
 
 	/**

--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -504,9 +504,9 @@ class CiviCRM_Caldera_Forms_Helper {
 	 *
 	 * @param string $date_picker_format The Caldera Forms date picker format
 	 */
-	public static function translate_date_picker_format( $date_picker_format ){
+	public function translate_date_picker_format( $date_picker_format ){
 		// Translate each token used in the CF date picker format to the corresponding PHP format character.
-		static $token_map = [
+		$token_map = [
 			'yyyy' => 'Y',
 			'yy'   => 'y',
 			'MM'   => 'F',


### PR DESCRIPTION
Overview
----------------------------------------
This patch ensures that when a CF date picker field is auto-populated, it uses the format specified by the date picker.

Before
----------------------------------------
When a processor auto-populated a form with the logged in user's data, any date values (e.g. date of birth) being put into date pickers were being left in the format in which they were returned from the CiviCRM API, e.g. 'yyyy-mm-dd'. If the date picker specified a different format, then the date picker misread and scrambled the date value.

After
----------------------------------------
When a processor is auto-populates a form with the logged in user's data, any date values being put into date pickers are converted to the format specified by the date picker.

Technical Details
----------------------------------------
[CF date pickers](https://calderaforms.com/doc/datepicker-field/) use a different formatting specification to [the one used by PHP date functions](http://php.net/manual/en/function.date.php). A new function - `translate_date_picker_format` - translates from the former to the latter.

This patch only reformats dates that have been left in ISO 8601 format (the format in which dates are returned by the CiviCRM API). This is to avoid any problems that might be caused if the value has been altered, e.g. by the `cfc_filter_mapped_field_to_prerender` filter.

Comments
----------------------------------------
This solution is not perfect, but it is better than before. Problems can still arise if the date picker's format includes literal text other than dashes or slashes, but in most cases it won't.