### PR TITLE
sort custom field by weight instead of id

### DIFF
--- a/fields/presets/class-civicrm-custom-fields-presets.php
+++ b/fields/presets/class-civicrm-custom-fields-presets.php
@@ -35,7 +35,7 @@ class CiviCRM_Caldera_Forms_Custom_Fields_Presets {
 	/**
 	 * The entites the custom fields extend.
 	 *
-	 * @since 1.0 
+	 * @since 1.0
 	 * @access public
 	 * @var array The entities
 	 */
@@ -93,9 +93,9 @@ class CiviCRM_Caldera_Forms_Custom_Fields_Presets {
 			if ( ! in_array( $field['html_type'], $this->allowed_html_types ) ) return;
 
 			if ( ! in_array( $field['custom_group_id.extends'], $extends ) ) return;
-			
+
 			if ( ! $field['option_group_id'] ) return;
-			
+
 			$custom_options = $this->option_values_get( $field['option_group_id'] );
 
 			if ( ! $custom_options ) return;
@@ -130,13 +130,13 @@ class CiviCRM_Caldera_Forms_Custom_Fields_Presets {
 		if ( ! $custom_fields ) return;
 
 		$extends = $this->entities_extend_get();
-		
+
 		array_map( function( $field ) use ( $extends ) {
 
 			if ( ! in_array( $field['html_type'], $this->allowed_html_types ) ) return;
 
 			if ( ! in_array( $field['custom_group_id.extends'], $extends ) ) return;
-			
+
 			if ( ! $field['option_group_id'] ) return;
 
 			echo "<option value=\"custom_{$field['id']}\"{{#is auto_type value=\"custom_{$field['id']}\"}} selected=\"selected\"{{/is}}>" . sprintf( __( 'CiviCRM - %1$s - %2$s', 'caldera-forms-civicrm' ), $field['custom_group_id.title'], $field['label'] ) . "</option>";
@@ -213,12 +213,12 @@ class CiviCRM_Caldera_Forms_Custom_Fields_Presets {
 
 
 		if ( ! is_array( $custom_fields ) && ! $custom_fields['count'] ) return false;
-		
+
 		// get option values
 		// $option_group_ids = array_column( $custom_fields['values'], 'option_group_id' );
 
 		$this->custom_fields = $custom_fields['values'];
-		
+
 		return $this->custom_fields;
 
 	}
@@ -235,7 +235,7 @@ class CiviCRM_Caldera_Forms_Custom_Fields_Presets {
 		$option_values = civicrm_api3( 'OptionValue', 'get', [
 			'sequential' => 1,
 			'option_group_id' => $option_group_id,
-			'options' => [ 'limit' => 0 ]
+      'options' => ['limit' => 0, 'sort' => "weight ASC"],
 		] );
 
 		if ( $option_values['count'] && ! $option_values['is_error'] ) return $option_values['values'];


### PR DESCRIPTION
Overview
----------------------------------------
Change the sorting order to sort by weight instead of sort by id. So users can control the order of option values.

Before
----------------------------------------
The option values are sorted by id.

After
----------------------------------------
The option values are sorted by weight.

Comments
----------------------------------------


Agileware ref: CFC-38