### PR TITLE
Avoid PHP notices about "invoicing" array key

### DIFF
--- a/fields/presets/class-civicrm-price-sets-presets.php
+++ b/fields/presets/class-civicrm-price-sets-presets.php
@@ -154,7 +154,7 @@ class CiviCRM_Caldera_Forms_Price_Sets_Presets {
 				'disabled' => $this->disable_all_fields
 			];
 
-			if ( isset( $price_field_value['tax_amount'] ) && $this->plugin->helper->get_tax_settings()['invoicing'] ) {
+			if ( isset( $price_field_value['tax_amount'] ) && $this->plugin->helper->get_tax_invoicing() ) {
 				$option['calc_value'] += $price_field_value['tax_amount'];
 				$option['label'] = $this->plugin->helper->format_tax_label( $price_field_value['label'], $price_field_value['amount'], $price_field_value['tax_amount'] );
 			}

--- a/includes/class-civicrm-caldera-forms-cividiscount.php
+++ b/includes/class-civicrm-caldera-forms-cividiscount.php
@@ -327,7 +327,7 @@ class CiviCRM_Caldera_Forms_CiviDiscount {
 		}, 10, 2 );
 
 		// has tax
-		if ( isset( $price_field_value['tax_amount'] ) && $this->plugin->helper->get_tax_settings()['invoicing'] ) {
+		if ( isset( $price_field_value['tax_amount'] ) && $this->plugin->helper->get_tax_invoicing() ) {
 			$option['calc_value'] += $price_field_value['tax_amount'];
 			$option['label'] = $this->plugin->helper->format_tax_label( $label, $discounted_amount, $price_field_value['tax_amount'] );
 		}

--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -648,6 +648,23 @@ class CiviCRM_Caldera_Forms_Helper {
 	}
 
 	/**
+	 * Get CiviCRM tax invoicing setting.
+	 *
+	 * @since 1.0.4
+	 * @return bool True if invoicing is set, false otherwise.
+	 */
+	public function get_tax_invoicing() {
+		$tax_settings = $this->get_tax_settings();
+		if ( ! array_key_exists( 'invoicing', $tax_settings ) ) {
+			return false;
+		}
+		if ( empty( $tax_settings['invoicing'] ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Get CiviCRM tax rates.
 	 *
 	 * @since 1.0
@@ -797,7 +814,7 @@ class CiviCRM_Caldera_Forms_Helper {
 				foreach ( $price_field_values as $value_id => $price_field_value) {
 					$price_field_value['price_field_value_id'] = $value_id;
 					if ( $price_field_id == $price_field_value['price_field_id'] ) {
-						if ( $tax_settings['invoicing'] && $tax_rates && array_key_exists( $price_field_value['financial_type_id'], $tax_rates ) ) {
+						if ( $this->get_tax_invoicing() && $tax_rates && array_key_exists( $price_field_value['financial_type_id'], $tax_rates ) ) {
 							$price_field_value['tax_rate'] = $tax_rates[$price_field_value['financial_type_id']];
 							$price_field_value['tax_amount'] = $this->calculate_percentage( $price_field_value['amount'], $price_field_value['tax_rate'] );
 						}

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -324,7 +324,7 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 
 			$line_item = $transient->line_items->$item_processor_id->params;
 
-			if ( isset( $line_item['line_item'][0]['tax_amount'] ) && $this->plugin->helper->get_tax_settings()['invoicing'] )
+			if ( isset( $line_item['line_item'][0]['tax_amount'] ) && $this->plugin->helper->get_tax_invoicing() )
 				$this->total_tax_amount += $line_item['line_item'][0]['tax_amount'];
 
 			// set membership as pending

--- a/processors/participant/class-participant-processor.php
+++ b/processors/participant/class-participant-processor.php
@@ -510,7 +510,7 @@ class CiviCRM_Caldera_Forms_Participant_Processor {
 				'calc_value' => $price_field_value['amount']
 			];
 
-			if ( $price_field_value['tax_amount'] && $this->plugin->helper->get_tax_settings()['invoicing'] ) {
+			if ( $price_field_value['tax_amount'] && $this->plugin->helper->get_tax_invoicing() ) {
 				$option['calc_value'] += $price_field_value['tax_amount'];
 				$option['label'] = $this->plugin->helper->format_tax_label( $price_field_value['label'], $price_field_value['amount'], $price_field_value['tax_amount'] );
 			}


### PR DESCRIPTION
Overview
----------------------------------------
As per title.

Before
----------------------------------------
PHP notices of the form:

`PHP Notice:  Undefined index: invoicing`

After
----------------------------------------
No PHP notices.
