### PR TITLE
Remove undefined var

### DIFF
--- a/cf-civicrm.php
+++ b/cf-civicrm.php
@@ -202,7 +202,7 @@ class CiviCRM_Caldera_Forms {
 
 		// Bail if unable to init CiviCRM
 		// FIXME This should only be called when needed
-		if ( ! civi_wp()->initialize() ) return $processors;
+		if ( ! civi_wp()->initialize() ) return false;
 
 		// we're good
 		return true;


### PR DESCRIPTION
Overview
----------------------------------------
Remove an unused variable from `check_dependencies()`

Before
----------------------------------------
If CiviCRM fails to initialise, a notice is logged:

`PHP Notice:  Undefined variable: processors`

After
----------------------------------------
No PHP notice.