### PR TITLE
Add case ID as form field

### DIFF
--- a/processors/case/case_config.php
+++ b/processors/case/case_config.php
@@ -17,7 +17,7 @@ $caseFieldsResult = civicrm_api3( 'Case', 'getfields', [
 
 $caseFields = [];
 foreach ( $caseFieldsResult['values'] as $key => $value ) {
-	if ( in_array( $value['name'], [ 'details', 'subject', 'start_date', 'end_date', 'created_date', 'modified_date' ] ) ) {
+	if ( in_array( $value['name'], [ 'id', 'details', 'subject', 'start_date', 'end_date', 'created_date', 'modified_date' ] ) ) {
 		$caseFields[$value['name']] = $value['title'];
 	}
 }

--- a/processors/case/class-case-processor.php
+++ b/processors/case/class-case-processor.php
@@ -151,7 +151,7 @@ class CiviCRM_Caldera_Forms_Case_Processor {
 			$form_values['start_date'] = date( 'YmdHis', strtotime( 'now' ) ); // Date format YYYYMMDDhhmmss
 
 		/**
-		 * Filter exisiting case.
+		 * Filter existing case.
 		 *
 		 * @since 1.0.5
 		 * @param array $result The api result
@@ -173,7 +173,7 @@ class CiviCRM_Caldera_Forms_Case_Processor {
 				$this->maybe_add_case_manager( $config, $create_case );
 
 				/**
-				 * Broadcast case cretion
+				 * Broadcast case creation
 				 *
 				 * @since 1.0.3
 				 * @param array $result The api result
@@ -200,7 +200,7 @@ class CiviCRM_Caldera_Forms_Case_Processor {
 	 * Add Case to extend custom fields autopopulation/presets.
 	 *
 	 * @since 1.0.3
-	 * @param array $extends The entites array
+	 * @param array $extends The entities array
 	 * @return array $extends The filtered entities array
 	 */
 	public function custom_fields_extend_case( $extends ) {

--- a/processors/case/class-case-processor.php
+++ b/processors/case/class-case-processor.php
@@ -154,6 +154,7 @@ class CiviCRM_Caldera_Forms_Case_Processor {
 		 * Filter existing case.
 		 *
 		 * @since 1.0.5
+		 *
 		 * @param array $result The api result
 		 * @param array $params The api parameters
 		 * @param array $config The processor config
@@ -163,8 +164,29 @@ class CiviCRM_Caldera_Forms_Case_Processor {
 
 		if( ! empty( $config['dismiss_case'] ) && ! empty( $existing_case['id'] ) ) {
 
-			// return exisiting case id magic tag
+			// return existing case id magic tag
 			return [ 'case_id' => $existing_case['id'] ];
+
+		} elseif ( !empty ( $config['id'] ) || !empty( $form_values['id'] ) ) {
+			// Did we specify case ID in processor config? Or via the form?
+			$caseContactParams = [
+				'case_id' => $config['id'] ?? $form_values['id'],
+				'contact_id' => $form_values['contact_id']
+			];
+			$add_contact_to_case = civicrm_api3( 'CaseContact', 'create', $caseContactParams);
+
+			/**
+			 * Broadcast case contact creation
+			 *
+			 * @since 1.0.6
+			 * @param array $result The api result
+			 * @param array $params The api parameters
+			 * @param array $config The processor config
+			 * @param array $form The form config
+			 */
+			do_action( 'cfc_case_processor_casecontact_create', $add_contact_to_case, $form_values, $config, $form );
+
+			return [ 'case_id' => $form_values['id'] ];
 
 		} else {
 			try {


### PR DESCRIPTION
Overview
----------------------------------------
This allows you to specify a field for the case ID so that you can add additional contacts to a case if "multiple case clients" is enabled in CiviCRM case settings.

Before
----------------------------------------
Cannot add new contacts to existing case.

After
----------------------------------------
Can add new contacts to existing case.

Technical Details
----------------------------------------


Comments
----------------------------------------

