### PR TITLE
Switch processors from 'pre_processor' to 'processor' stage and other fixes

### DIFF
--- a/includes/class-civicrm-caldera-forms-cividiscount.php
+++ b/includes/class-civicrm-caldera-forms-cividiscount.php
@@ -361,7 +361,11 @@ class CiviCRM_Caldera_Forms_CiviDiscount {
 	 */
 	public function apply_code_discount( $form ) {
 
-		if ( empty( $this->options_ids_refs ) ) return $form;
+		$price_field_refs = $this->plugin->helper->build_price_field_refs( $form );
+		if ( empty( $price_field_refs ) ) return $form;
+
+		$price_field_option_refs = $this->build_options_ids_refs( $price_field_refs, $form );
+		if ( empty( $price_field_option_refs ) ) return $form;
 
 		$discount_field = $this->plugin->cividiscount->get_discount_fields( $form );
 		if ( empty( $discount_field ) ) return $form;
@@ -385,7 +389,7 @@ class CiviCRM_Caldera_Forms_CiviDiscount {
 				$this->apply_option_filter_discount( $line_item, $ref, $entities_discounts, $form );
 
 			},
-			$this->options_ids_refs
+			$price_field_option_refs
 		);
 
 		return $form;

--- a/includes/class-civicrm-caldera-forms-cividiscount.php
+++ b/includes/class-civicrm-caldera-forms-cividiscount.php
@@ -170,6 +170,8 @@ class CiviCRM_Caldera_Forms_CiviDiscount {
 
 			if ( empty( $price_field_field ) || empty( $price_field_field['ID'] ) ) return $refs;
 
+			if ( empty( $price_field_field['config']['option'] ) ) return $refs;
+
 			if ( empty( $discounted_options[$processor_id] ) ) {
 
 				$refs[$field_id] = [

--- a/includes/class-civicrm-caldera-forms-cividiscount.php
+++ b/includes/class-civicrm-caldera-forms-cividiscount.php
@@ -467,7 +467,9 @@ class CiviCRM_Caldera_Forms_CiviDiscount {
 			);
 		}
 
-		$discount = $discounts[$processor['ID']];
+		$discount = count( $discounts ) > 1 && isset( $discounts[$processor['ID']] )
+			? $discounts[$processor['ID']]
+			: current( $discounts );
 
 		$price_field_filter_function = function( $field, $form, $price_field ) use ( &$ref, &$discount ) {
 
@@ -563,15 +565,13 @@ class CiviCRM_Caldera_Forms_CiviDiscount {
 
 				$processor = $form['processors'][$processor_id];
 
-				// discount entity for this line item
-				$discount_entity = $this->get_discount_entity_map(
-					$processor['config']['entity_table']
-				);
-
-				if ( empty( $discount[$discount_entity] ) ) return $discounted_options;
-
 				// no need to check entities if options are set in discounted priceset options
 				if ( empty( array_intersect( $ref['field_options'], $discount['pricesets'] ) ) ) {
+
+					// discount entity for this line item
+					$discount_entity = $this->get_discount_entity_map(
+						$processor['config']['entity_table']
+					);
 
 					// check applied discount is for an event, membership or contribution present on the form
 					switch ( $processor['config']['entity_table'] ) {

--- a/includes/class-civicrm-caldera-forms-cividiscount.php
+++ b/includes/class-civicrm-caldera-forms-cividiscount.php
@@ -570,54 +570,59 @@ class CiviCRM_Caldera_Forms_CiviDiscount {
 
 				if ( empty( $discount[$discount_entity] ) ) return $discounted_options;
 
-				// check applied discount is for an event, membership or contribution present on the form
-				switch ( $processor['config']['entity_table'] ) {
-					// events based discount
-					case 'civicrm_participant':
-						$participant = $this->plugin->helper->get_processor_from_magic(
-							$processor['config']['entity_params'],
-							$form,
-							true
-						);
-						if (
-							! in_array(
-								$participant['config']['id'],
-								$discount[$discount_entity]
-							)
-						) return $discounted_options;
-						break;
+				// no need to check entities if options are set in discounted priceset options
+				if ( empty( array_intersect( $ref['field_options'], $discount['pricesets'] ) ) ) {
 
-					// membership based discount
-					case 'civicrm_membership':
-						$membership = $this->plugin->helper->get_processor_from_magic(
-							$processor['config']['entity_params'],
-							$form,
-							true
-						);
-						if (
-							! in_array(
-								$membership['config']['membership_type_id'],
-								$discount[$discount_entity]
-							)
-						) return $discounted_options;
-						break;
+					// check applied discount is for an event, membership or contribution present on the form
+					switch ( $processor['config']['entity_table'] ) {
+						// events based discount
+						case 'civicrm_participant':
+							$participant = $this->plugin->helper->get_processor_from_magic(
+								$processor['config']['entity_params'],
+								$form,
+								true
+							);
+							if (
+								! in_array(
+									$participant['config']['id'],
+									$discount[$discount_entity]
+								)
+							) return $discounted_options;
+							break;
 
-					// contribution based discount
-					case 'civicrm_contribution':
-						$order = current(
-							$this->plugin->helper->get_processor_by_type( 'civicrm_order', $form )
-						);
+						// membership based discount
+						case 'civicrm_membership':
+							$membership = $this->plugin->helper->get_processor_from_magic(
+								$processor['config']['entity_params'],
+								$form,
+								true
+							);
+							if (
+								! in_array(
+									$membership['config']['membership_type_id'],
+									$discount[$discount_entity]
+								)
+							) return $discounted_options;
+							break;
 
-						// bail if no order or no contribution page
-						if ( empty( $order ) || empty( $order['config']['contribution_page_id'] ) ) return $discounted_options;
+						// contribution based discount
+						case 'civicrm_contribution':
+							$order = current(
+								$this->plugin->helper->get_processor_by_type( 'civicrm_order', $form )
+							);
 
-						if (
-							! in_array(
-								$order['config']['contribution_page_id'],
-								$discount[$discount_entity]
-							)
-						) return $discounted_options;
-						break;
+							// bail if no order or no contribution page
+							if ( empty( $order ) || empty( $order['config']['contribution_page_id'] ) ) return $discounted_options;
+
+							if (
+								! in_array(
+									$order['config']['contribution_page_id'],
+									$discount[$discount_entity]
+								)
+							) return $discounted_options;
+							break;
+					}
+
 				}
 
 				$field = $fields[$ref['field_id']];
@@ -724,7 +729,7 @@ class CiviCRM_Caldera_Forms_CiviDiscount {
 						if ( in_array( $processor['config']['id'], $discount['events'] ) ) {
 							$discounts[$processor['ID']] = $discount;
 						}
-					} else { 
+					} else {
 						$cividiscounts = $this->get_cividiscounts_by_entity( 'events', $autodiscount );
 						array_map( function( $discount ) use ( &$discounts, $processor ) {
 							if ( in_array( $processor['config']['id'], $discount['events'] ) ) {

--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -1158,6 +1158,7 @@ class CiviCRM_Caldera_Forms_Helper {
 		} else {
 			// one processor, the format is processor_type:processor_id
 			$processor = $this->get_processor_by_type( $parts[0], $form );
+			$processor = array_pop( $processor );
 			$processor_id = $processor['ID'];
 		}
 

--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -472,6 +472,8 @@ class CiviCRM_Caldera_Forms_Helper {
 					Caldera_Forms_Field_Util::get_field( $field_id, $form ) :
 					Caldera_Forms::get_field_by_slug(str_replace( '%', '', $field_id ), $form );
 
+				if ( empty( $field ) || empty( $field['type'] ) ) continue;
+
 				// don't prerender hidden field values unless pre_render enable
 				if ( $field['type'] == 'hidden' && ! isset( $field['config']['pre_render'] ) ) continue;
 
@@ -494,9 +496,13 @@ class CiviCRM_Caldera_Forms_Helper {
 				 * @param array $entity The current entity, i.e. Contact, Address, etc
 				 * @param array $config processor config
 				 */
-				$form['fields'][$field['ID']]['config']['default'] = apply_filters( 'cfc_filter_mapped_field_to_prerender', $value, $civi_field, $field, $entity, $config );
+				$value = apply_filters( 'cfc_filter_mapped_field_to_prerender', $value, $civi_field, $field, $entity, $config );
 
-				if ( $field['type'] == 'radio' ) {
+				if ( $value !== '' ) {
+					$form['fields'][$field['ID']]['config']['default'] = $value;
+				}
+
+				if ( $field['type'] == 'radio' && $value !== '' ) {
 					$options = Caldera_Forms_Field_Util::find_option_values( $field );
 					$form['fields'][$field['ID']]['config']['default'] = array_search( $value, $options );
 				}

--- a/processors/contact/class-contact-processor.php
+++ b/processors/contact/class-contact-processor.php
@@ -201,11 +201,14 @@ class CiviCRM_Caldera_Forms_Contact_Processor {
 			}
 
 			// contact reference field for organization maps to an array [ 'organization_name' => <name>, 'employer_id' => <id> ]
-			if ( ! empty( $form_values['civicrm_contact']['current_employer'] ) && is_array( $form_values['civicrm_contact']['current_employer'] ) ) {
-				$org = $form_values['civicrm_contact']['current_employer'];
-				$form_values['civicrm_contact']['current_employer'] = $org['organization_name'];
-				// need to be set in case of duplicate orgs with same name
-				$form_values['civicrm_contact']['employer_id'] = $org['employer_id'];
+			if (
+				! empty( $form_values['civicrm_contact']['current_employer'] )
+				&& is_array( $form_values['civicrm_contact']['current_employer'] )
+				&& ! empty( $form_values['civicrm_contact']['current_employer']['employer_id'] )
+			) {
+				$form_values['civicrm_contact']['employer_id'] = $form_values['civicrm_contact']['current_employer']['employer_id'];
+				// need to remove current_employer otherwise Civi will do a dedupe on the organization name
+				unset( $form_values['civicrm_contact']['current_employer'] );
 			}
 
 			/**

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -341,7 +341,7 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 		} );
 
 		// updated participant registered_by_id and status
-		if ( is_array( $participant_entities ) && count( $participant_entities ) > 1 ) {
+		if ( is_array( $participant_entities ) ) {
 
 			$participant_ids = array_keys( $participant_entities );
 			$main_participant_id = array_slice( $participant_ids, -1 )[0];

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -252,6 +252,14 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 
 		$this->order = $this->create_order_payment( $charge_metadata, $this->order );
 
+		if ( empty( $this->order['line_items'] ) ) {
+			try {
+				$this->order = civicrm_api3( 'Order', 'getsingle', ['contribution_id' => $this->order['id']] );
+			} catch ( CiviCRM_API3_Exception $e ) {
+				// log error?
+			}
+		}
+
 		if ( true ) { //$config['is_thank_you'] ) {
 			add_filter( 'caldera_forms_ajax_return', function( $out, $_form ) use ( $transdata, $transient ){
 

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -451,14 +451,14 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 			if ( $contribution && ! empty( $participant_statuses ) ) {
 
 				array_map(
-					function( $participant_id, $participant_status ) use ( $contribution ) {
+					function( $participant_id, $participant_status ) use ( $current_order ) {
 
 						if ( $participant_status == 1 ) return;
 
 						$params = [
 							'id' => $participant_id,
 							'status_id' => 'Registered',
-							'register_date' => $contribution['receive_date']
+							'register_date' => $current_order['receive_date']
 						];
 
 						try {

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -250,8 +250,10 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 			$charge_metadata = $this->stripe_metadata;
 		}
 
+		if ( ! empty( $charge_metadata ) ) {
 		// don't send confirmation, we are calling Contribution.sendconfirmation afterwards
 		$charge_metadata = array_merge( $charge_metadata, ['is_send_contribution_notification' => 0] );
+		}
 
 		$this->order = $this->create_order_payment( $charge_metadata, $this->order );
 

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -157,6 +157,10 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 		$form_values['currency'] = $config['currency'];
 		$form_values['receive_date'] = get_date_from_gmt( 'now' );
 
+		if ( ! empty( $config['is_email_receipt'] ) ) {
+			$form_values['receipt_date'] = $form_values['receive_date'];
+		}
+
 		if ( ! empty( $config['campaign_id'] ) ) $form_values['campaign_id'] = $config['campaign_id'];
 
 		// contribution page for reciepts

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -448,9 +448,11 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 			$payment = null;
 		}
 
-		if ( $payment && empty( $payment['trxn_id'] ) && ! empty( $payment_params['trxn_id'] ) ) {
+		if ( ( $payment && empty( $payment['trxn_id'] ) && ! empty( $payment_params['trxn_id'] ) )
+			|| ( $payment && $payment['trxn_date'] != $payment_params['trxn_date'] )
+		) {
 
-			$payment_params = array_merge( $payment_params, $payment );
+			$payment_params = array_merge( $payment, $payment_params );
 
 			// update payment/financial_trxn to add transaction id
 			try {

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -155,6 +155,7 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 			$form_values['mapped_payment_instrument_id'];
 
 		$form_values['currency'] = $config['currency'];
+		$form_values['receive_date'] = get_date_from_gmt( 'now' );
 
 		if ( ! empty( $config['campaign_id'] ) ) $form_values['campaign_id'] = $config['campaign_id'];
 
@@ -393,7 +394,7 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 			[
 				'contribution_id' => $current_order['id'],
 				'total_amount' => $current_order['total_amount'],
-				'trxn_date' => 'now',
+				'trxn_date' => get_date_from_gmt( 'now' ),
 			],
 			$metadata
 		);

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -428,6 +428,8 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 					'contribution_status_id' => 'Completed',
 				];
 
+				$order_params = array_merge( $order_params, $payment_params );
+
 				$contribution = civicrm_api3( 'Contribution', 'create', $order_params );
 
 			} catch ( CiviCRM_API3_Exception $e ) {

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -250,6 +250,9 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 			$charge_metadata = $this->stripe_metadata;
 		}
 
+		// don't send confirmation, we are calling Contribution.sendconfirmation afterwards
+		$charge_metadata = array_merge( $charge_metadata, ['is_send_contribution_notification' => 0] );
+
 		$this->order = $this->create_order_payment( $charge_metadata, $this->order );
 
 		if ( empty( $this->order['line_items'] ) ) {

--- a/processors/order/class-order-processor.php
+++ b/processors/order/class-order-processor.php
@@ -251,8 +251,8 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 		}
 
 		if ( ! empty( $charge_metadata ) ) {
-		// don't send confirmation, we are calling Contribution.sendconfirmation afterwards
-		$charge_metadata = array_merge( $charge_metadata, ['is_send_contribution_notification' => 0] );
+			// don't send confirmation, we are calling Contribution.sendconfirmation afterwards
+			$charge_metadata = array_merge( $charge_metadata, ['is_send_contribution_notification' => 0] );
 		}
 
 		$this->order = $this->create_order_payment( $charge_metadata, $this->order );
@@ -397,6 +397,10 @@ class CiviCRM_Caldera_Forms_Order_Processor {
 			],
 			$metadata
 		);
+
+		if ( ! empty( $current_order['payment_instrument_id'] ) ) {
+			$payment_params['payment_instrument_id'] = $current_order['payment_instrument_id'];
+		}
 
 		if ( $current_order['contribution_status'] == 'Pending' ) {
 			// complete payment

--- a/processors/order/order_config.php
+++ b/processors/order/order_config.php
@@ -11,6 +11,14 @@ $contribution_status = civicrm_api3( 'Contribution', 'getoptions', [
   'field' => 'contribution_status_id',
 ] );
 
+$contribution_status['values'] = array_merge(
+	[[
+		'key' => 'default_status_id',
+		'value' => __( 'Default Status (Pending)', 'cf-civicrm' )
+	]],
+	$contribution_status['values']
+);
+
 $payment_instruments = civicrm_api3( 'Contribution', 'getoptions', [
 	'field' => 'payment_instrument_id',
 ] );

--- a/processors/order/order_config.php
+++ b/processors/order/order_config.php
@@ -175,14 +175,6 @@ $campaigns = civicrm_api3( 'Campaign', 'get', [
 	</p>
 </div>
 
-<!-- Recieve Date -->
-<div id="{{_id}}_receive_date" class="caldera-config-group">
-	<label><?php _e( 'Receive Date', 'cf-civicrm' ); ?></label>
-	<div class="caldera-config-field">
-		{{{_field slug="receive_date"}}}
-	</div>
-</div>
-
 <!-- Transaction ID -->
 <div id="{{_id}}_trxn_id" class="caldera-config-group">
 	<label><?php _e( 'Transaction ID', 'cf-civicrm' ); ?></label>

--- a/processors/participant/class-participant-processor.php
+++ b/processors/participant/class-participant-processor.php
@@ -971,11 +971,11 @@ class CiviCRM_Caldera_Forms_Participant_Processor {
 
 		$statuses = civicrm_api3( 'ParticipantStatusType', 'get', [
 			'sequential' => 1,
-			'return' => ['name'],
+			'return' => ['name', 'label'],
 			'is_counted' => 1,
 		] );
 
-		return array_column( $statuses['values'], 'name' );
+		return array_column( $statuses['values'], 'label' );
 
 	}
 

--- a/processors/participant/class-participant-processor.php
+++ b/processors/participant/class-participant-processor.php
@@ -313,8 +313,11 @@ class CiviCRM_Caldera_Forms_Participant_Processor {
 					$this->plugin->transient->save( $transient->ID, $transient );
 
 				} catch ( CiviCRM_API3_Exception $e ) {
-					$error = $e->getMessage() . '<br><br><pre>' . $e->getTraceAsString() . '</pre>';
-					return [ 'note' => $error, 'type' => 'error' ];
+					// add error to notices, don't stop form processing
+					add_filter( 'caldera_forms_render_notices', function( $notices ) use ( $e ) {
+						$notices['error']['note'] = $e->getMessage() . '<br><br><pre>' . $e->getTraceAsString() . '</pre>';
+						return $notices;
+					} );
 				}
 			}
 

--- a/processors/participant/class-participant-processor.php
+++ b/processors/participant/class-participant-processor.php
@@ -1103,7 +1103,24 @@ class CiviCRM_Caldera_Forms_Participant_Processor {
 
 		}
 
-		return (bool) $is_registered;
+		/**
+		 * Filter is_resgitered flag.
+		 *
+		 * @since 1.0.6
+		 * @param bool $is_registered
+		 * @param array $participant
+		 * @param array $event
+		 * @param array $config
+		 * @param array $form
+		 */
+		return apply_filters(
+			'cfc_participant_processor_is_registered',
+			(bool) $is_registered,
+			$participant,
+			$event,
+			$config,
+			$form
+		);
 
 	}
 

--- a/processors/participant/class-participant-processor.php
+++ b/processors/participant/class-participant-processor.php
@@ -975,10 +975,7 @@ class CiviCRM_Caldera_Forms_Participant_Processor {
 			'is_counted' => 1,
 		] );
 
-		return array_merge(
-			array_column( $statuses['values'], 'name' ),
-			['Pending (pay later)'] // participant_status comes as Pending (pay later) not Pending from pay later
-		);
+		return array_column( $statuses['values'], 'name' );
 
 	}
 

--- a/processors/participant/class-participant-processor.php
+++ b/processors/participant/class-participant-processor.php
@@ -1056,7 +1056,7 @@ class CiviCRM_Caldera_Forms_Participant_Processor {
 			'is_counted' => 1,
 		] );
 
-		return array_column( $statuses['values'], 'label' );
+		return array_column( $statuses['values'], 'name' );
 
 	}
 

--- a/processors/participant/class-participant-processor.php
+++ b/processors/participant/class-participant-processor.php
@@ -975,7 +975,10 @@ class CiviCRM_Caldera_Forms_Participant_Processor {
 			'is_counted' => 1,
 		] );
 
-		return array_column( $statuses['values'], 'name' );
+		return array_merge(
+			array_column( $statuses['values'], 'name' ),
+			['Pending (pay later)'] // participant_status comes as Pending (pay later) not Pending from pay later
+		);
 
 	}
 


### PR DESCRIPTION
Overview
----------------------------------------

* move processors from `pre_processor` to `processor` stage
* added Pending status to the Order processor (it should be the default status)
* use `Payment.create` or `Contribution.create` to complete a Contribution/Order
* enforce order receive date in local timezone and ensure transaction date matches contribution receive date
* Order/Payment/Participant fixes and workarounds
* add support for Stripe add-on v1.4.9
* support query `event_id` for generic Event form registrations
* add `cfc_participant_processor_is_registered` filter
