### PR TITLE
Add relationship start and end dates to the relationship processor

### DIFF
--- a/processors/relationship/relationship_config.php
+++ b/processors/relationship/relationship_config.php
@@ -6,6 +6,10 @@ $relationships = civicrm_api3( 'RelationshipType', 'get', [
 	'options' => [ 'limit' => 0 ],
 ] );
 
+$relationshipFields = civicrm_api3( 'Relationship', 'getfields', [] );
+
+$fields = [ 'start_date', 'end_date' ];
+
 ?>
 
 <div id="{{_id}}_relationship_type" class="caldera-config-group">
@@ -54,3 +58,17 @@ $relationships = civicrm_api3( 'RelationshipType', 'get', [
 		</select>
 	</div>
 </div>
+
+<?php
+foreach ( $relationshipFields['values'] as $value ) {
+	if ( in_array($value['name'], $fields ) ) {
+		?>
+		<div id="{{_id}}_<?= $value['name'] ?>" class="caldera-config-group">
+			<label><?= __($value['title'], 'cf-civicrm') ?></label>
+			<div class="caldera-config-field">
+				{{{_field slug="<?= $value['name'] ?>"}}}
+			</div>
+		</div>
+		<?php
+	}
+}


### PR DESCRIPTION
Overview
----------------------------------------
This pull request adds relationship start and end date fields to the relationship processor, as requested in issue #166.

Before
----------------------------------------
The relationship processor did not include fields for the relationship start and end dates.

![Screenshot](https://user-images.githubusercontent.com/48320029/88820633-77f63300-d1b9-11ea-8867-88b8f7462f34.png)

After
----------------------------------------
The relationship processor includes optional fields for the relationship start and end dates. These are dropdowns which can be used to select a Field or a System Tag.

![Screenshot](https://user-images.githubusercontent.com/48320029/88820665-82183180-d1b9-11ea-8524-7a2848eb3cd3.png)

Technical Details
----------------------------------------
I have employed patterns used by other processors to iterate over the fields.

Comments
----------------------------------------
If no start or end date is supplied, then the processor's behaviour is unchanged. If a single relationship of the specified type between the specified contacts already exists, then its start and/or end dates will be updated. If _multiple_ matching relationships already exist, then the processor will do nothing.