### PR TITLE
Set PHP default timezone during processors processing

### DIFF
--- a/includes/class-civicrm-caldera-forms-forms.php
+++ b/includes/class-civicrm-caldera-forms-forms.php
@@ -26,6 +26,13 @@ class CiviCRM_Caldera_Forms_Forms {
 	protected $transient_id;
 
 	/**
+	 * @since  1.0.5
+	 * @access protected
+	 * @var string the timezone string before changing
+	 */
+	protected $original_timezone;
+
+	/**
 	 * Initialises this object.
 	 *
 	 * @since 0.4
@@ -58,6 +65,10 @@ class CiviCRM_Caldera_Forms_Forms {
 		// form submission transient
 		add_filter( 'caldera_forms_submit_get_form', [ $this, 'set_form_transient' ] );
 		add_action( 'caldera_forms_submit_complete', [ $this, 'delete_form_transient' ] );
+
+		// set PHP default timezone for CiviCRM and reset for WordPress after processors done
+		add_action( 'caldera_forms_submit_start_processors', [ $this, 'set_timezone' ], 10, 3 );
+		add_action( 'caldera_forms_submit_complete', [ $this, 'reset_timezone' ], 10, 4 );
 		
 		// add CiviCRM panel
 		if ( in_array( 'CiviContribute', $this->plugin->processors->enabled_components ) )  
@@ -104,6 +115,27 @@ class CiviCRM_Caldera_Forms_Forms {
 	 */
 	public function delete_form_transient() {
 		return $this->plugin->transient->delete();
+	}
+
+	/**
+	 * Set timezone to WP timezone
+	 *
+	 * @access public
+	 * @since 1.0.5
+	 */
+	public function set_timezone($form, $referrer, $process_id) {
+		$this->original_timezone = date_default_timezone_get();
+		date_default_timezone_set( wp_timezone_string() );
+	}
+
+	/**
+	 * Reset timezone
+	 *
+	 * @access public
+	 * @since 1.0.5
+	 */
+	public function reset_timezone($form, $referrer, $process_id, $entryid) {
+		date_default_timezone_set( $this->original_timezone );
 	}
 
 	/**


### PR DESCRIPTION
WordPress seems to expect the PHP default timezone to be UTC. This will cause Civi to record the wrong date-time with the CFC processor. Here is a way to fix it. #167 #169 

Before
----------------------------------------
Civi records the wrong date-time

After
----------------------------------------
Civi records the right date-time

Technical Details
----------------------------------------
May cause wrong date-time record in non CFC processors if them depends on WP date-time system. I didn't see any of them but just mentioned here. So there may be a better solution than this.

Comments
----------------------------------------
This is the current solution we are using.

Agileware ref: CFC-61
