### PR TITLE
Fixes spelling mistake "Do not foget to enable this option for the related Contacts"

### DIFF
--- a/processors/contact/contact_config.php
+++ b/processors/contact/contact_config.php
@@ -3,7 +3,7 @@
 		<div class="caldera-config-field">
 			<label><input id="auto_pop" type="checkbox" name="{{_name}}[auto_pop]" value="1" {{#if auto_pop}}checked="checked"{{/if}}><?php _e( 'Auto populate contact data with CiviCRM data if user is logged in.', 'cf-civicrm' ); ?></label>
 		</div>
-		<p class="description"><?php _e( 'For related Contacts (relationship based contacts) add another Contact Processor (you can add more than one) plus a Relationship Processor, and use the Contact 1 as the A or B relationship. Do not foget to enable this option for the related Contacts (Contact Processor 1, 2, 3, etc.).' ) ?></p>
+		<p class="description"><?php _e( 'For related Contacts (relationship based contacts) add another Contact Processor (you can add more than one) plus a Relationship Processor, and use the Contact 1 as the A or B relationship. Do not forget to enable this option for the related Contacts (Contact Processor 1, 2, 3, etc.).' ) ?></p>
 	</div>
 	<div class="caldera-config-group caldera-config-group-full">
 		<div class="caldera-config-field">


### PR DESCRIPTION
Overview
----------------------------------------
This pull request fixes spelling mistake in CiviCRM Contact Processor.

Before
----------------------------------------
"Do not foget to enable this option for the related Contacts"
[
![Screenshot_20201012_133131](https://user-images.githubusercontent.com/65804219/96216457-14b3ba00-0fcc-11eb-9a14-80cdec8a6503.png)
](url)
After
----------------------------------------
"Do not forget to enable this option for the related Contacts"
![Screen Shot 2020-10-16 at 2 36 22 pm](https://user-images.githubusercontent.com/65804219/96216480-27c68a00-0fcc-11eb-9cb1-3860850d4ccd.png)

Comments
----------------------------------------

Agileware ref: CFC-72