### PR TITLE
Priceset Field Values are not sorted by weight, instead sorted by default API order

### DIFF
--- a/includes/class-civicrm-caldera-forms-helper.php
+++ b/includes/class-civicrm-caldera-forms-helper.php
@@ -800,7 +800,7 @@ class CiviCRM_Caldera_Forms_Helper {
 			$all_price_field_values = civicrm_api3( 'PriceFieldValue', 'get', [
 				'sequential' => 0,
 				'is_active' => 1,
-				'options' => [ 'limit' => 0 ],
+				'options' => [ 'limit' => 0, 'sort' => 'weight ASC' ],
 			] );
 		} catch ( CiviCRM_API3_Exception $e ) {
 			return [ 'note' => $e->getMessage(), 'type' => 'error' ];


### PR DESCRIPTION
Priceset Field Values are not sorted by weight, instead sorted by default API order

Overview
----------------------------------------
Priceset Field Values are not sorted by weight, instead sorted by default API order

Before
----------------------------------------
Priceset Field Values are displayed in the wrong order.

After
----------------------------------------
Priceset Field Values are displayed according to their weight, appear in correct order.

Technical Details
----------------------------------------
Added weight sort to API call.

Agileware Ref: CFC-75