### PR TITLE
add double opt-in support for group

### DIFF
--- a/processors/group/group_config.php
+++ b/processors/group/group_config.php
@@ -30,3 +30,11 @@ $groupsResult = civicrm_api3( 'Group', 'get', [
 		</select>
 	</div>
 </div>
+
+<hr style="clear: both;" />
+
+<div class="caldera-config-group">
+	<div class="caldera-config-field">
+		<label><input id="{{_id}}_double_optin" type="checkbox" name="{{_name}}[double_optin]" value="1" {{#if double_optin}}checked="checked" {{/if}}><?php _e('Enable double opt-in?', 'cf-civicrm'); ?></label>
+	</div>
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
_Add a configurable option for enabling double opt-in while adding contact to the group_

Before
----------------------------------------
_Currently contact are directly added to the group. Double opt-in is needed in case of mailing sign up etc._

After
----------------------------------------
_If double opt-in is enabled then contact needs to verify the email sent and then the contact is added to the group_

Technical Details
----------------------------------------
_PR is self explanatory_

Comments
----------------------------------------
_Thank you for the wonderful plugin_
