### PR TITLE
Always add Location Type ID when adding or updating an Address

### DIFF
--- a/processors/address/class-address-processor.php
+++ b/processors/address/class-address-processor.php
@@ -107,9 +107,10 @@ class CiviCRM_Caldera_Forms_Address_Processor {
 				// Pass address ID if we got one
 				if ( isset( $address ) && is_array( $address ) ) {
 					$form_values['id'] = $address['id']; // Address ID
-				} else {
-					$form_values['location_type_id'] = $config['location_type_id']; // Address Location Type
 				}
+
+				// Always add Location Type ID
+				$form_values['location_type_id'] = $config['location_type_id'];
 
 				// FIXME
 				// Concatenate DATE + TIME


### PR DESCRIPTION
Overview
----------------------------------------
The Location Type ID should be set from the Form Config regardless of whether it is a `create` or `edit` operation.

Before
----------------------------------------
Say, for example, a Caldera Form's CiviCRM Address Processor settings are changed and a different Location Type is chosen - Addresses that are updated after this change has been made to the Processor will not have their Location Type updated.

After
----------------------------------------
Addresses that are updated after changing a Caldera Form's CiviCRM Address Processor Location Type setting will have their Location Type updated.

Technical Details
----------------------------------------
Simply cleans up the `create`/`edit` logic such that the Address ID is the only item that is optionally added.

FYI, this was discovered because the `civicrm_post` hook only includes the data that is submitted in the API call. Since the Location Type ID was missing in Address `edit` operation, various downstream changes that relied on the presence of the Location Type ID did not occur.