### PR TITLE
Always add Location Type ID when adding or updating an Address - replicate PR #200 for class-contact-processor

### DIFF
--- a/processors/contact/class-contact-processor.php
+++ b/processors/contact/class-contact-processor.php
@@ -331,9 +331,10 @@ class CiviCRM_Caldera_Forms_Contact_Processor {
 				// Pass address ID if we got one
 				if ( isset( $address ) && is_array( $address ) ) {
 					$form_values['civicrm_address']['id'] = $address['id']; // Address ID
-				} else {
-					$form_values['civicrm_address']['location_type_id'] = $config['civicrm_address']['location_type_id'];
 				}
+
+				// Always add Location Type ID
+				$form_values['civicrm_address']['location_type_id'] = $config['civicrm_address']['location_type_id'];
 
 				// FIXME
 				// Concatenate DATE + TIME


### PR DESCRIPTION
Always use location_type_id.   This PR accompanies https://github.com/mecachisenros/cf-civicrm/pull/200  and adds same logic to the contact processor
